### PR TITLE
Nether roof veins & some fixes

### DIFF
--- a/World Beyond [Assets]/models/mobs.json
+++ b/World Beyond [Assets]/models/mobs.json
@@ -357,7 +357,7 @@
         "name": "rightItem",
         "pivot": [ -6, 15, 1 ],
         "locators": {
-          "lead_hold": [ -6, 15, 1 ]
+          "lead_hold": [ -6, 14.5, 1 ]
         },
         "parent": "rightArm"
       },

--- a/World Beyond [Assets]/textures/terrain_texture.json
+++ b/World Beyond [Assets]/textures/terrain_texture.json
@@ -161,7 +161,7 @@
             "textures": "textures/blocks/stones/sodalite/cracked_sodalite_bricks"
         },
         "cracked_sodalite_tiles": {
-            "textures": "textures/blocks/stones/bauxite/cracked_sodalite_tiles"
+            "textures": "textures/blocks/stones/sodalite/cracked_sodalite_tiles"
         },
         "crystal_bottom": {
             "textures": "textures/blocks/crystal_bottom"

--- a/World Beyond [Data]/feature_rules/nether/nether_wart_ceiling.json
+++ b/World Beyond [Data]/feature_rules/nether/nether_wart_ceiling.json
@@ -1,0 +1,33 @@
+{
+	"format_version": "1.13",
+	
+	"minecraft:feature_rules": {
+		"description": {
+			"identifier": "worldbeyond:nether_wart_ceiling",
+			"places_feature": "worldbeyond:nether/nether_wart_grid"
+		},
+		"conditions": {
+			"placement_pass": "first_pass",
+			"minecraft:biome_filter": {
+				"any_of": [
+					{
+						"test": "has_biome_tag",
+						"value": "crimson_forest"
+					}
+				]
+			}
+		},
+		"distribution": {
+			"iterations": 256,
+			"x": {
+				"distribution": "fixed_grid",
+				"extent": [0, 15]
+			},
+			"z": {
+				"distribution": "fixed_grid",
+				"extent": [0, 15]
+			},
+			"y": 88
+		}
+	}
+}

--- a/World Beyond [Data]/feature_rules/nether/warped_wart_ceiling.json
+++ b/World Beyond [Data]/feature_rules/nether/warped_wart_ceiling.json
@@ -1,0 +1,33 @@
+{
+	"format_version": "1.13",
+	
+	"minecraft:feature_rules": {
+		"description": {
+			"identifier": "worldbeyond:warped_wart_ceiling",
+			"places_feature": "worldbeyond:nether/warped_wart_grid"
+		},
+		"conditions": {
+			"placement_pass": "first_pass",
+			"minecraft:biome_filter": {
+				"any_of": [
+					{
+						"test": "has_biome_tag",
+						"value": "warped_forest"
+					}
+				]
+			}
+		},
+		"distribution": {
+			"iterations": 256,
+			"x": {
+				"distribution": "fixed_grid",
+				"extent": [0, 15]
+			},
+			"z": {
+				"distribution": "fixed_grid",
+				"extent": [0, 15]
+			},
+			"y": 88
+		}
+	}
+}

--- a/World Beyond [Data]/features/nether/nether_wart.json
+++ b/World Beyond [Data]/features/nether/nether_wart.json
@@ -1,0 +1,20 @@
+{
+	"format_version": "1.13",
+	"minecraft:single_block_feature": {
+		"description": {
+			"identifier": "worldbeyond:nether/nether_wart"
+		},
+		"places_block": "minecraft:nether_wart_block",
+		"enforce_placement_rules": false,
+		"enforce_survivability_rules": false,
+		"may_replace": [
+			"minecraft:netherrack",
+			"minecraft:quartz_ore",
+			"minecraft:nether_gold_ore",
+			"minecraft:blackstone"
+		],
+		"may_attach_to": {
+			"bottom": "minecraft:air"
+		}
+	}
+}

--- a/World Beyond [Data]/features/nether/nether_wart_grid.json
+++ b/World Beyond [Data]/features/nether/nether_wart_grid.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.13.0",
+	"minecraft:scatter_feature": {
+		"description": {
+			"identifier": "worldbeyond:nether/nether_wart_grid"
+		},
+		"places_feature": "worldbeyond:nether/nether_wart_scatter",
+		"iterations": "t.big_noise = q.noise(v.originx/32, v.originz/32); t.small_noise = q.noise(v.originx/90, v.originz/90); return 28;",
+		"x": 0,
+		"z": 0,
+		"y": {
+			"distribution": "fixed_grid",
+			"extent": [0, 28]
+		}
+	}
+}

--- a/World Beyond [Data]/features/nether/nether_wart_scatter.json
+++ b/World Beyond [Data]/features/nether/nether_wart_scatter.json
@@ -1,0 +1,13 @@
+{
+	"format_version": "1.13.0",
+	"minecraft:scatter_feature": {
+		"description": {
+			"identifier": "worldbeyond:nether/nether_wart_scatter"
+		},
+		"places_feature": "worldbeyond:nether/nether_wart",
+		"iterations": "(t.big_noise > -0.3 && t.big_noise < 0.15) || (t.small_noise > -0.035 && t.small_noise < 0.035)",
+		"x": 0,
+		"z": 0,
+		"y": 0
+	}
+}

--- a/World Beyond [Data]/features/nether/warped_wart.json
+++ b/World Beyond [Data]/features/nether/warped_wart.json
@@ -1,0 +1,20 @@
+{
+	"format_version": "1.13",
+	"minecraft:single_block_feature": {
+		"description": {
+			"identifier": "worldbeyond:nether/warped_wart"
+		},
+		"places_block": "minecraft:warped_wart_block",
+		"enforce_placement_rules": false,
+		"enforce_survivability_rules": false,
+		"may_replace": [
+			"minecraft:netherrack",
+			"minecraft:quartz_ore",
+			"minecraft:nether_gold_ore",
+			"minecraft:blackstone"
+		],
+		"may_attach_to": {
+			"bottom": "minecraft:air"
+		}
+	}
+}

--- a/World Beyond [Data]/features/nether/warped_wart_grid.json
+++ b/World Beyond [Data]/features/nether/warped_wart_grid.json
@@ -1,0 +1,16 @@
+{
+	"format_version": "1.13.0",
+	"minecraft:scatter_feature": {
+		"description": {
+			"identifier": "worldbeyond:nether/warped_wart_grid"
+		},
+		"places_feature": "worldbeyond:nether/warped_wart_scatter",
+		"iterations": "t.big_noise = q.noise(v.originx/32, v.originz/32); t.small_noise = q.noise(v.originx/90, v.originz/90); return 28;",
+		"x": 0,
+		"z": 0,
+		"y": {
+			"distribution": "fixed_grid",
+			"extent": [0, 28]
+		}
+	}
+}

--- a/World Beyond [Data]/features/nether/warped_wart_scatter.json
+++ b/World Beyond [Data]/features/nether/warped_wart_scatter.json
@@ -1,0 +1,13 @@
+{
+	"format_version": "1.13.0",
+	"minecraft:scatter_feature": {
+		"description": {
+			"identifier": "worldbeyond:nether/warped_wart_scatter"
+		},
+		"places_feature": "worldbeyond:nether/warped_wart",
+		"iterations": "(t.big_noise > -0.3 && t.big_noise < 0.15) || (t.small_noise > -0.035 && t.small_noise < 0.035)",
+		"x": 0,
+		"z": 0,
+		"y": 0
+	}
+}


### PR DESCRIPTION
Nether changes
- Added warped wart veins to the Warped Forest roof
- Added nether wart veins to the Crimson Forest roof

Fixes
- Fixed a model-related content log error
- Fixed an issue with the cracked sodalite tiles texture